### PR TITLE
Fix Frends.Tasks.Attributes reference to a working version (1.2.1)

### DIFF
--- a/Frends.ServiceBus.sln
+++ b/Frends.ServiceBus.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.27004.2006
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Frends.ServiceBus", "Frends.ServiceBus\Frends.ServiceBus.csproj", "{22EB5924-3103-461B-88BE-60AE79F86407}"
 EndProject
@@ -10,6 +10,11 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "nuspec", "nuspec", "{E105E543-7A4D-4379-A50A-2D9605CA94AC}"
 	ProjectSection(SolutionItems) = preProject
 		nuspec\Frends.ServiceBus.nuspec = nuspec\Frends.ServiceBus.nuspec
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{38572141-E12B-40E0-AAE2-92B41F07128E}"
+	ProjectSection(SolutionItems) = preProject
+		README.md = README.md
 	EndProjectSection
 EndProject
 Global
@@ -29,5 +34,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {A49539E0-4F8F-40B5-AD4C-CF5173126779}
 	EndGlobalSection
 EndGlobal

--- a/Frends.ServiceBus/Frends.ServiceBus.csproj
+++ b/Frends.ServiceBus/Frends.ServiceBus.csproj
@@ -33,8 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Frends.Tasks.Attributes, Version=1.2.0.0, Culture=neutral, PublicKeyToken=258fd606323928fc, processorArchitecture=MSIL">
-      <HintPath>..\packages\Frends.Tasks.Attributes.1.2.0\lib\net40\Frends.Tasks.Attributes.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Frends.Tasks.Attributes.1.2.1\lib\net40\Frends.Tasks.Attributes.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.ServiceBus, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\ServiceBus.v1_1.1.0.6\lib\net40-full\Microsoft.ServiceBus.dll</HintPath>

--- a/Frends.ServiceBus/packages.config
+++ b/Frends.ServiceBus/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Frends.Tasks.Attributes" version="1.2.0" targetFramework="net452" />
+  <package id="Frends.Tasks.Attributes" version="1.2.1" targetFramework="net452" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.0.0" targetFramework="net452" />
   <package id="ServiceBus.v1_1" version="1.0.6" targetFramework="net452" />
 </packages>

--- a/README.md
+++ b/README.md
@@ -1,16 +1,10 @@
-- [Frends.ServiceBus](#frends.servicebus)
+- [Frends.ServiceBus](#frendsservicebus)
    - [Installing](#installing)
    - [Building](#building)
    - [Contributing](#contributing)
    - [Documentation](#documentation)
-     - [ServiceBus.Send](#servicebus.send)
-       - [Input](#input)
-       - [Options](#options)
-       - [Result](#result)
-     - [ServiceBus.Read](#servicebus.read)
-       - [Input](#input)
-       - [Options](#options)
-       - [Result](#result)
+     - [ServiceBus.Send](#servicebussend) 
+     - [ServiceBus.Read](#servicebusread)
    - [License](#license)
    
 # Frends.ServiceBus
@@ -21,7 +15,6 @@ You can install the task via FRENDS UI Task view or you can find the nuget packa
 `https://www.myget.org/F/frends/api/v2`
 
 ## Building
-Ensure that you have `https://www.myget.org/F/frends/api/v2` added to your nuget feeds
 
 Clone a copy of the repo
 

--- a/nuspec/Frends.ServiceBus.nuspec
+++ b/nuspec/Frends.ServiceBus.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
   <metadata>
     <id>Frends.ServiceBus</id>
-    <version>1.0.0.0</version>
+    <version>0.7.20</version>
     <title>FRENDS Service bus tasks</title>
     <authors>HiQ Finland</authors>
     <owners />
@@ -10,7 +10,6 @@
     <description>FRENDS Service bus tasks</description>
     <summary />
     <dependencies>
-      <dependency id="Frends.Tasks.Attributes" version="1.2.0" />
       <dependency id="ServiceBus.v1_1" version="1.0.6.0" />
       <dependency id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.0.0" />
     </dependencies>


### PR DESCRIPTION
Version 1.2.0 from nuget.org cannot be used as it has the wrong assembly version, so compilation will fail.