### PR TITLE
Replaced Frends.tasks.attributes with System.ComponentModel.DataAnnotations

### DIFF
--- a/Frends.ServiceBus/Definitions.cs
+++ b/Frends.ServiceBus/Definitions.cs
@@ -1,8 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.ServiceModel;
-using Frends.Tasks.Attributes;
+using System.ComponentModel.DataAnnotations;
 
 namespace Frends.ServiceBus
 {
@@ -20,7 +19,7 @@ namespace Frends.ServiceBus
         /// </summary>
         UTF32,
         /// <summary>
-        /// ASCII 
+        /// ASCII
         /// </summary>
         ASCII,
         /// <summary>
@@ -38,7 +37,6 @@ namespace Frends.ServiceBus
     /// </summary>
     public enum BodySerializationType
     {
-        
         /// <summary>
         /// As a stream
         /// </summary>
@@ -120,7 +118,7 @@ namespace Frends.ServiceBus
         public string MessageId { get; set; }
 
         /// <summary>
-        /// Message's session id, if set messages can be filtered according to the session id. Also the messages are handled on the same service bus broker ensuring delivery order. 
+        /// Message's session id, if set messages can be filtered according to the session id. Also the messages are handled on the same service bus broker ensuring delivery order.
         /// </summary>
         public string SessionId { get; set; }
 
@@ -129,13 +127,13 @@ namespace Frends.ServiceBus
         /// </summary>
         public string CorrelationId { get; set; }
         /// <summary>
-        /// The reply to field for the message, can be used to specify the name 
+        /// The reply to field for the message, can be used to specify the name
         /// of the queue where the receiver of the message should reply to
         /// </summary>
         public string ReplyTo { get; set; }
 
         /// <summary>
-        /// The reply to session id field for the message, can be used to specify the session id for a reply message  
+        /// The reply to session id field for the message, can be used to specify the session id for a reply message
         /// </summary>
         public string ReplyToSessionId { get; set; }
 
@@ -165,7 +163,7 @@ namespace Frends.ServiceBus
         /// <summary>
         /// Is the destination a queue or a topic, used when creating a non-existant destination
         /// </summary>
-        [ConditionalDisplay(nameof(CreateQueueOrTopicIfItDoesNotExist), true)]
+        [UIHint(nameof(CreateQueueOrTopicIfItDoesNotExist), "", true)]
         [DefaultValue(QueueOrTopic.Queue)]
         public QueueOrTopic DestinationType { get; set; }
 
@@ -176,7 +174,7 @@ namespace Frends.ServiceBus
         public bool UseCachedConnection { get; set; }
 
         /// <summary>
-        /// Timeout in seconds 
+        /// Timeout in seconds
         /// </summary>
         [DefaultValue(60)]
         public long TimeoutSeconds { get; set; }
@@ -248,7 +246,7 @@ namespace Frends.ServiceBus
         /// <summary>
         /// The name of the subscription
         /// </summary>
-        [ConditionalDisplay(nameof(SourceType), QueueOrSubscription.Subscription)]
+        [UIHint(nameof(SourceType), "", QueueOrSubscription.Subscription)]
         public string SubscriptionName { get; set; }
         /// <summary>
         /// ServiceBus connection string
@@ -289,7 +287,7 @@ namespace Frends.ServiceBus
         /// The name of the encoding for the message contents
         /// </summary>
         [DefaultValue("\"UTF-8\"")]
-        [ConditionalDisplay(nameof(DefaultEncoding), MessageEncoding.Other)]
+        [UIHint(nameof(DefaultEncoding), "", MessageEncoding.Other)]
         public string EncodingName { get; set; }
         /// <summary>
         /// Should the existence of the message source be checked and created if it does not exist. Elements created by this are automatically deleted once they're idle for 7 days

--- a/Frends.ServiceBus/Frends.ServiceBus.csproj
+++ b/Frends.ServiceBus/Frends.ServiceBus.csproj
@@ -32,9 +32,6 @@
     <DocumentationFile>bin\Release\Frends.ServiceBus.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Frends.Tasks.Attributes, Version=1.2.0.0, Culture=neutral, PublicKeyToken=258fd606323928fc, processorArchitecture=MSIL">
-      <HintPath>..\packages\Frends.Tasks.Attributes.1.2.1\lib\net40\Frends.Tasks.Attributes.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.ServiceBus, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\ServiceBus.v1_1.1.0.6\lib\net40-full\Microsoft.ServiceBus.dll</HintPath>
       <Private>True</Private>
@@ -44,6 +41,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.Serialization" />

--- a/Frends.ServiceBus/ServiceBus.cs
+++ b/Frends.ServiceBus/ServiceBus.cs
@@ -1,11 +1,11 @@
 ﻿using System;
+using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Net.Mime;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Frends.Tasks.Attributes;
 using Microsoft.ServiceBus;
 using Microsoft.ServiceBus.Messaging;
 
@@ -86,7 +86,7 @@ namespace Frends.ServiceBus
         /// Send data to the Service Bus, don't wait for a reply. See https://github.com/FrendsPlatform/Frends.ServiceBus
         /// </summary>
         /// <returns>Object: {MessageId, SessionId, ContentType}</returns>
-        public static async Task<SendResult> Send([CustomDisplay(DisplayOption.Tab)]SendInput input, [CustomDisplay(DisplayOption.Tab)]SendOptions options, CancellationToken cancellationToken = new CancellationToken())
+        public static async Task<SendResult> Send([PropertyTab]SendInput input, [PropertyTab]SendOptions options, CancellationToken cancellationToken = new CancellationToken())
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -245,7 +245,7 @@ namespace Frends.ServiceBus
         /// <param name="options">Option parameters</param>
         /// <param name="cancellationToken"></param>
         /// <returns>Object {ReceivedMessage(boolean), ContentType, SessionId, MessageId, CorrelationId, DeliveryCount, EnqueuedSequenceNumber, SequenceNumber, Label, Properties(dictionary), ReplyTo, ReplyToSessionId, Size, State, To, Content}</returns>
-        public static async Task<ReadResult> Read([CustomDisplay(DisplayOption.Tab)]ReadInput input, [CustomDisplay(DisplayOption.Tab)]ReadOptions options,
+        public static async Task<ReadResult> Read([PropertyTab]ReadInput input, [PropertyTab]ReadOptions options,
             CancellationToken cancellationToken = new CancellationToken())
         {
             cancellationToken.ThrowIfCancellationRequested();

--- a/Frends.ServiceBus/packages.config
+++ b/Frends.ServiceBus/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Frends.Tasks.Attributes" version="1.2.1" targetFramework="net452" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.0.0" targetFramework="net452" />
   <package id="ServiceBus.v1_1" version="1.0.6" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Replaced usage of custom attributes from Frends.tasks.attributes with their counterparts from System.ComponentModel.DataAnnotations, as the Frends.Tasks.Attributes reference mostly does not work together with older versions